### PR TITLE
KAFKA-14650: Synchronize access to tasks inside task manager

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -60,7 +60,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -1269,16 +1268,23 @@ public class StreamThread extends Thread {
         );
     }
 
-    public Map<TaskId, Task> activeTaskMap() {
-        return taskManager.activeTaskMap();
+    /**
+     * Getting the list of current active tasks of the thread;
+     * Note that the returned list may be used by other thread than the StreamThread itself,
+     * and hence need to be read-only
+     */
+    public Set<Task> readOnlyActiveTasks() {
+        return readyOnlyAllTasks().stream()
+            .filter(Task::isActive).collect(Collectors.toSet());
     }
 
-    public List<Task> activeTasks() {
-        return taskManager.activeTaskIterable();
-    }
-
-    public Map<TaskId, Task> allTasks() {
-        return taskManager.allTasks();
+    /**
+     * Getting the list of all owned tasks of the thread, including both active and standby;
+     * Note that the returned list may be used by other thread than the StreamThread itself,
+     * and hence need to be read-only
+     */
+    public Set<Task> readyOnlyAllTasks() {
+        return taskManager.readOnlyAllTasks();
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -1537,6 +1537,12 @@ public class TaskManager {
         return tasks.allTasksPerId();
     }
 
+    Set<Task> readOnlyAllTasks() {
+        // need to make sure the returned set is unmodifiable as it could be accessed
+        // by other thread than the StreamThread owning this task manager;
+        return Collections.unmodifiableSet(tasks.allTasks());
+    }
+
     Map<TaskId, Task> notPausedTasks() {
         return Collections.unmodifiableMap(tasks.allTasks()
             .stream()

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Tasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Tasks.java
@@ -45,6 +45,8 @@ class Tasks implements TasksRegistry {
     private final Logger log;
 
     // TODO: convert to Stream/StandbyTask when we remove TaskManager#StateMachineTask with mocks
+    // note that these two maps may be accessed by concurrent threads and hence
+    // should be synchronized when accessed
     private final Map<TaskId, Task> activeTasksPerId = new TreeMap<>();
     private final Map<TaskId, Task> standbyTasksPerId = new TreeMap<>();
 
@@ -203,7 +205,7 @@ class Tasks implements TasksRegistry {
     }
 
     @Override
-    public void addTask(final Task task) {
+    public synchronized void addTask(final Task task) {
         final TaskId taskId = task.id();
         if (activeTasksPerId.containsKey(taskId)) {
             throw new IllegalStateException("Attempted to create an active task that we already own: " + taskId);
@@ -225,7 +227,7 @@ class Tasks implements TasksRegistry {
     }
 
     @Override
-    public void removeTask(final Task taskToRemove) {
+    public synchronized void removeTask(final Task taskToRemove) {
         final TaskId taskId = taskToRemove.id();
 
         if (taskToRemove.state() != Task.State.CLOSED) {
@@ -245,7 +247,7 @@ class Tasks implements TasksRegistry {
     }
 
     @Override
-    public void replaceActiveWithStandby(final StandbyTask standbyTask) {
+    public synchronized void replaceActiveWithStandby(final StandbyTask standbyTask) {
         final TaskId taskId = standbyTask.id();
         if (activeTasksPerId.remove(taskId) == null) {
             throw new IllegalStateException("Attempted to replace unknown active task with standby task: " + taskId);
@@ -256,7 +258,7 @@ class Tasks implements TasksRegistry {
     }
 
     @Override
-    public void replaceStandbyWithActive(final StreamTask activeTask) {
+    public synchronized void replaceStandbyWithActive(final StreamTask activeTask) {
         final TaskId taskId = activeTask.id();
         if (standbyTasksPerId.remove(taskId) == null) {
             throw new IllegalStateException("Attempted to convert unknown standby task to stream task: " + taskId);
@@ -295,7 +297,7 @@ class Tasks implements TasksRegistry {
     }
 
     @Override
-    public void clear() {
+    public synchronized void clear() {
         activeTasksPerId.clear();
         standbyTasksPerId.clear();
         activeTasksPerPartition.clear();
@@ -307,7 +309,7 @@ class Tasks implements TasksRegistry {
         return activeTasksPerPartition.get(partition);
     }
 
-    private Task getTask(final TaskId taskId) {
+    private synchronized Task getTask(final TaskId taskId) {
         if (activeTasksPerId.containsKey(taskId)) {
             return activeTasksPerId.get(taskId);
         }
@@ -337,7 +339,7 @@ class Tasks implements TasksRegistry {
     }
 
     @Override
-    public Collection<Task> activeTasks() {
+    public synchronized Collection<Task> activeTasks() {
         return Collections.unmodifiableCollection(activeTasksPerId.values());
     }
 
@@ -346,17 +348,17 @@ class Tasks implements TasksRegistry {
      * and the returned task could be modified by other threads concurrently
      */
     @Override
-    public Set<Task> allTasks() {
+    public synchronized Set<Task> allTasks() {
         return union(HashSet::new, new HashSet<>(activeTasksPerId.values()), new HashSet<>(standbyTasksPerId.values()));
     }
 
     @Override
-    public Set<TaskId> allTaskIds() {
+    public synchronized Set<TaskId> allTaskIds() {
         return union(HashSet::new, activeTasksPerId.keySet(), standbyTasksPerId.keySet());
     }
 
     @Override
-    public Map<TaskId, Task> allTasksPerId() {
+    public synchronized Map<TaskId, Task> allTasksPerId() {
         final Map<TaskId, Task> ret = new HashMap<>();
         ret.putAll(activeTasksPerId);
         ret.putAll(standbyTasksPerId);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/KafkaStreamsNamedTopologyWrapper.java
@@ -436,7 +436,7 @@ public class KafkaStreamsNamedTopologyWrapper extends KafkaStreams {
         }
         final List<Task> allTopologyTasks = new ArrayList<>();
         processStreamThread(thread -> allTopologyTasks.addAll(
-            thread.allTasks().values().stream()
+            thread.readyOnlyAllTasks().stream()
                 .filter(t -> topologyName.equals(t.id().topologyName()))
                 .collect(Collectors.toList())));
         return allLocalStorePartitionLags(allTopologyTasks);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
@@ -56,7 +56,7 @@ public class StreamThreadStateStoreProvider {
 
         if (storeQueryParams.staleStoresEnabled() ? state.isAlive() : state == StreamThread.State.RUNNING) {
             final Collection<Task> tasks = storeQueryParams.staleStoresEnabled() ?
-                    streamThread.allTasks().values() : streamThread.activeTasks();
+                    streamThread.readyOnlyAllTasks() : streamThread.readOnlyActiveTasks();
 
             if (storeQueryParams.partition() != null) {
                 for (final Task task : tasks) {

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -93,7 +93,6 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.safeUniqueTestName;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitForApplicationState;
@@ -363,8 +362,8 @@ public class KafkaStreamsTest {
             }).when(thread).join();
         }
 
-        when(thread.activeTasks()).thenReturn(emptyList());
-        when(thread.allTasks()).thenReturn(Collections.emptyMap());
+        when(thread.readOnlyActiveTasks()).thenReturn(Collections.emptySet());
+        when(thread.readyOnlyAllTasks()).thenReturn(Collections.emptySet());
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
@@ -69,10 +69,10 @@ import org.mockito.junit.MockitoJUnitRunner;
 import java.io.File;
 import java.io.IOException;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -464,7 +464,7 @@ public class StreamThreadStateStoreProviderTest {
     }
 
     private void mockThread(final boolean initialized) {
-        when(threadMock.activeTasks()).thenReturn(new ArrayList<>(tasks.values()));
+        when(threadMock.readOnlyActiveTasks()).thenReturn(new HashSet<>(tasks.values()));
         when(threadMock.state()).thenReturn(
             initialized ? StreamThread.State.RUNNING : StreamThread.State.PARTITIONS_ASSIGNED
         );


### PR DESCRIPTION
1) The major fix: synchronize access to tasks inside task manager, this is a fix of a regression introduced in https://github.com/apache/kafka/pull/12397
2) Clarify on func names of StreamThread that maybe triggered outside the StreamThread.
3) Minor cleanups.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
