### PR TITLE
KAFKA-14727: Enable periodic offset commits for EOS source tasks

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractWorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractWorkerSourceTask.java
@@ -353,8 +353,10 @@ public abstract class AbstractWorkerSourceTask extends WorkerTask {
                         recordPollReturned(toSend.size(), time.milliseconds() - start);
                     }
                 }
-                if (toSend == null)
+                if (toSend == null) {
+                    batchDispatched();
                     continue;
+                }
                 log.trace("{} About to send {} records to Kafka", this, toSend.size());
                 if (sendRecords()) {
                     batchDispatched();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ExactlyOnceWorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ExactlyOnceWorkerSourceTask.java
@@ -255,10 +255,6 @@ class ExactlyOnceWorkerSourceTask extends AbstractWorkerSourceTask {
 
         long started = time.milliseconds();
 
-        // We might have just aborted a transaction, in which case we'll have to begin a new one
-        // in order to commit offsets
-        maybeBeginTransaction();
-
         AtomicReference<Throwable> flushError = new AtomicReference<>();
         boolean shouldFlush = false;
         try {
@@ -269,6 +265,20 @@ class ExactlyOnceWorkerSourceTask extends AbstractWorkerSourceTask {
         } catch (Throwable e) {
             flushError.compareAndSet(null, e);
         }
+        if (flushError.get() == null && !transactionOpen && !shouldFlush) {
+            // There is no contents on the framework side to commit, so skip the offset flush and producer commit
+            long durationMillis = time.milliseconds() - started;
+            recordCommitSuccess(durationMillis);
+            log.debug("{} Finished commitOffsets successfully in {} ms", this, durationMillis);
+
+            commitSourceTask();
+            return;
+        }
+
+        // We might have just aborted a transaction, in which case we'll have to begin a new one
+        // in order to commit offsets
+        maybeBeginTransaction();
+
         if (shouldFlush) {
             // Now we can actually write the offsets to the internal topic.
             // No need to track the flush future here since it's guaranteed to complete by the time
@@ -393,7 +403,7 @@ class ExactlyOnceWorkerSourceTask extends AbstractWorkerSourceTask {
         }
 
         private void maybeCommitTransaction(boolean shouldCommit) {
-            if (shouldCommit && (transactionOpen || offsetWriter.willFlush())) {
+            if (shouldCommit) {
                 try (LoggingContext loggingContext = LoggingContext.forOffsets(id)) {
                     commitTransaction();
                 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/OffsetStorageWriter.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/OffsetStorageWriter.java
@@ -151,13 +151,6 @@ public class OffsetStorageWriter {
     }
 
     /**
-     * @return whether there's anything to flush right now.
-     */
-    public synchronized boolean willFlush() {
-        return !data.isEmpty();
-    }
-
-    /**
      * Flush the current offsets and clear them from this writer. This is non-blocking: it
      * moves the current set of offsets out of the way, serializes the data, and asynchronously
      * writes the data to the backing store. If no offsets need to be written, the callback is


### PR DESCRIPTION
Source tasks in non-EOS mode periodically call SourceTask::commit even if no records are returned from poll.
This change adds that behavior to EOS mode by considering empty batches to be dispatched immediately, thus giving the transaction boundary manager an opportunity to initiate a commit.

This does not address tasks which spend a long time in poll(). In non-EOS mode, these tasks would get concurrent commit() calls, while in EOS mode the commit() calls will only occur while a poll() is not in-progress. Tasks which want to receive periodic commit() calls should periodically release control by returning null from poll.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
