### PR TITLE
KAFKA-14717 KafkaStreams can' get running if the rebalance happens be…

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -627,8 +627,12 @@ public class KafkaStreams implements AutoCloseable {
          * If all threads are up, including the global thread, set to RUNNING
          */
         private void maybeSetRunning() {
-            // state can be transferred to RUNNING if all threads are either RUNNING or DEAD
+            // state can be transferred to RUNNING if
+            // 1) all threads are either RUNNING or DEAD
+            // 2) thread is pending-shutdown and there are still other threads running
+            final boolean hasRunningThread = threadState.values().stream().anyMatch(s -> s == StreamThread.State.RUNNING);
             for (final StreamThread.State state : threadState.values()) {
+                if (state == StreamThread.State.PENDING_SHUTDOWN && hasRunningThread) continue;
                 if (state != StreamThread.State.RUNNING && state != StreamThread.State.DEAD) {
                     return;
                 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -192,6 +192,10 @@ public class StreamThread extends Thread {
         stateListener = listener;
     }
 
+    public StreamThread.StateListener getStateListener() {
+        return stateListener;
+    }
+
     /**
      * @return The state this instance is in
      */

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsWrapper.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsWrapper.java
@@ -16,6 +16,8 @@
  */
 package org.apache.kafka.streams;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 
 import org.apache.kafka.streams.KafkaStreams.State;
@@ -30,6 +32,10 @@ public class KafkaStreamsWrapper extends KafkaStreams {
     public KafkaStreamsWrapper(final Topology topology,
                                final Properties props) {
         super(topology, props);
+    }
+
+    public List<StreamThread> streamThreads() {
+        return new ArrayList<>(threads);
     }
 
     /**

--- a/streams/src/test/java/org/apache/kafka/streams/integration/AdjustStreamThreadCountTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/AdjustStreamThreadCountTest.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.LogCaptureAppender;
 import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KafkaStreamsWrapper;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
@@ -32,7 +33,9 @@ import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.Transformer;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.PunctuationType;
+import org.apache.kafka.streams.processor.internals.StreamThread;
 import org.apache.kafka.test.TestUtils;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -255,6 +258,37 @@ public class AdjustStreamThreadCountTest {
             }
             latch.countDown();
         });
+    }
+
+    @Test
+    public void testRebalanceHappensBeforeStreamThreadGetDown() throws Exception {
+        try (final KafkaStreamsWrapper kafkaStreams = new KafkaStreamsWrapper(builder.build(), properties)) {
+            addStreamStateChangeListener(kafkaStreams);
+            startStreamsAndWaitForRunning(kafkaStreams);
+            stateTransitionHistory.clear();
+
+            final StreamThread thread = kafkaStreams.streamThreads().get(0);
+            final StreamThread.StateListener listener = thread.getStateListener();
+            final CountDownLatch latchBeforeDead = new CountDownLatch(1);
+            thread.setStateListener((thread1, newState, oldState) -> {
+                final StreamThread.State current = (StreamThread.State) newState;
+                if (current == StreamThread.State.DEAD) {
+                    try {
+                        // block the pending shutdown thread to test whether other running thread
+                        // can make kafka streams running
+                        latchBeforeDead.await(DEFAULT_DURATION.toMillis(), TimeUnit.MILLISECONDS);
+                    } catch (final InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+                listener.onChange(thread1, newState, oldState);
+            });
+            final Optional<String> threadName = kafkaStreams.removeStreamThread();
+            assertThat(threadName.isPresent(), Matchers.is(true));
+            assertEquals(thread.getName(), threadName.get());
+            waitForTransitionFromRebalancingToRunning();
+            latchBeforeDead.countDown();
+        }
     }
 
     @Test


### PR DESCRIPTION
I noticed this issue when tracing #12590
StreamThread closes the consumer before changing state to DEAD. If the partition rebalance happens quickly, the other StreamThreads can't change KafkaStream state from REBALANCING to RUNNING since there is a PENDING_SHUTDOWN StreamThread

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
